### PR TITLE
drm_framebuffer is only included on 5.15.0 and later

### DIFF
--- a/module/evdi_drm_drv.h
+++ b/module/evdi_drm_drv.h
@@ -26,10 +26,7 @@
 #include <drm/drmP.h>
 #endif
 #if KERNEL_VERSION(5, 15, 0) <= LINUX_VERSION_CODE || defined(EL9)
-#include <drm/drm_legacy.h>
-#if KERNEL_VERSION(6, 0, 0) <= LINUX_VERSION_CODE
 #include <drm/drm_framebuffer.h>
-#endif
 #else
 #include <drm/drm_irq.h>
 #endif


### PR DESCRIPTION
Before submitting the PR please make sure you have run *ci* scripts:
  * `./ci/build_against_kernel` (see `--help` for all options)
    We need backward compatibility and this script is a handy way of testing
    build compliance with many kernel versions.
  * `./ci/run_style_check`
    We want to be as style compliant as possible. Again, this is a handy way of
    checking it.

If you have more than one change consider creating separate PRs for them; it
will make the review process much easier. Also provide some description (links
to source code or mailing list are welcome - this might help to understand the
change).

Thanks for the contribution!
